### PR TITLE
Upgrade sleep to 2.0 to fix yosemite compilation problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "aws-sdk": "2.0.x",
     "minimist": "1.1.x",
-    "sleep": "1.1.x",
+    "sleep": "2.0.x",
     "dotenv": "0.4.x"
   },
   "devDependencies": {


### PR DESCRIPTION
I've upgraded to sleep 2.0 to fix the problem I was having in #15 

I also noted that other users have problems with the older version of sleep on Yosemite: 

https://github.com/ErikDubbelboer/node-sleep/issues/26
