### PR TITLE
Upgrade sleep

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "aws-sdk": "2.0.x",
     "minimist": "1.1.x",
-    "sleep": "1.1.x",
+    "sleep": "3.0.x",
     "dotenv": "0.4.x"
   },
   "devDependencies": {


### PR DESCRIPTION
This replaces the patch in #16, and works for me on El Capitan with nodejs 4.x+.