### PR TITLE
Added export to CSV format and --endpoint optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![NPM version](https://badge.fury.io/js/dynamo-archive.svg)](http://badge.fury.io/js/dynamo-archive)
 [![Dependency Status](https://gemnasium.com/yegor256/dynamo-archive.svg)](https://gemnasium.com/yegor256/dynamo-archive)
 
-## Archive and Restore AWS Dynamo DB Table
+## Archive, Restore and Export to CSV AWS Dynamo DB Table
 
-There are two simple Node.js scripts that archive and restore an entire
+There are three simple Node.js scripts that archive, restore and export to csv an entire
 [AWS Dynamo DB](http://aws.amazon.com/dynamodb/)
 table in JSON format.
 
@@ -77,4 +77,3 @@ Licensed under the Apache License, Version 2.0.
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/yegor256/dynamo-archive/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/README.md
+++ b/README.md
@@ -71,6 +71,33 @@ do
 done
 ```
 
+You can also save locally and export to csv
+
+```bash
+#/bin/bash
+
+AWS_ACCESS_KEY_ID=AKIAJK.......XWGA5AA
+AWS_SECRET_ACCESS_KEY=7aDUFa68GN....................IGcH0zTf3k
+#/bin/bash
+#make a dir with the current datetime and cd into it
+DT=$(date +%Y%m%d_%H%M%S)
+mkdir $DT && cd $DT
+#archive all into json files
+declare -a TABLES=(first second third)
+for t in ${TABLES[@]}
+do
+	dynamo-archive/bin/dynamo-archive.js --table=$t > $t.json
+done
+#export the json into csv
+for t in ${TABLES[@]}
+do
+	dynamo-archive/bin/dynamo-export.js --file=$t.json > $t.csv
+done
+cd ../
+
+```
+
+
 ## License
 
 Licensed under the Apache License, Version 2.0.

--- a/bin/dynamo-archive.js
+++ b/bin/dynamo-archive.js
@@ -19,9 +19,9 @@ var sleep = require('sleep');
 
 var argv = utils.config({
     demand: ['table'],
-    optional: ['rate', 'query', 'key', 'secret', 'region'],
+    optional: ['rate', 'query', 'key', 'secret', 'region', 'endpoint'],
     usage: 'Archives Dynamo DB table to standard output in JSON\n' +
-           'Usage: dynamo-archive --table my-table [--rate 100] [--query "{}"] [--region us-east-1] [--key AK...AA] [--secret 7a...IG]'
+           'Usage: dynamo-archive --table my-table [--rate 100] [--query "{}"] [--region us-east-1] [--key AK...AA] [--secret 7a...IG] [--endpoint http://localhost:8000]'
 });
 
 var dynamo = utils.dynamo(argv);

--- a/bin/dynamo-export.js
+++ b/bin/dynamo-export.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Copyright 2017 Ali Alaoui
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var utils = require('../lib/utils');
+var sleep = require('sleep');
+var fs = require('fs');
+var readline = require('readline');
+
+var unmarshalItem = require('dynamodb-marshaler').unmarshalItem;
+var moment = require('moment-timezone');
+
+
+//-- Set default timezone
+moment.tz.setDefault("Europe/Paris");
+moment.locale('fr');
+
+//--
+var argv = utils.config({
+    demand: ['file'],
+    optional: [],
+    usage: 'Generates a CSV file from a JSON file\n' +
+           'Usage: ddbutocsv --file my-file'
+});
+
+
+function writeDateToCsv(headers, file) {
+   //-- Get the rest of the items
+   readline.createInterface({
+      input: fs.createReadStream(argv.file)
+   }).on('line', function(line) {
+
+      var values
+      var header
+      var value
+
+      //-- JSON parse, unmarshal and flatten
+      var item = utils.flatten(unmarshalItem(JSON.parse(line)))
+
+      //-- Stores the headers
+      values = [];
+      for (i = 0; i < headers.length; i++) {
+            value = ""
+            header = headers[i]
+            //-- Loop through the header rows, adding values if they exist
+            if (item.hasOwnProperty(header)) {
+               value = item[header]
+               //-- Check if timestamp, there is maybe a better way to do this
+               if(typeof value === "number" && value > 1400000000000)
+                  value = moment(parseInt(value)).format('dddd D MMMM YYYY à kk:mm')
+
+            } else {
+               value = ""
+            }
+           values.push(value)
+      }
+
+      process.stdout.write(utils.csv(values))
+      process.stdout.write("\n")
+
+    });
+
+}
+
+
+//-- headers
+var headers = [];
+
+//-- Get the headers
+readline.createInterface({
+      input: fs.createReadStream(argv.file)
+   }).on('line',function(line) {
+
+   //-- JSON parse, unmarshal and flatten
+   var item = utils.flatten(unmarshalItem(JSON.parse(line)))
+
+   //-- Stores the headers
+   for (var key in item) {
+      if(headers.indexOf(key) == -1 ) {
+         headers.push(key)
+      }
+   }
+
+   }).on('close', function() {
+      //-- Print to file
+      process.stdout.write(utils.csv(headers))
+      process.stdout.write("\n")
+
+      //-- Now process all data
+      writeDateToCsv(headers, argv.file)
+   }
+);

--- a/bin/dynamo-export.js
+++ b/bin/dynamo-export.js
@@ -59,7 +59,7 @@ function writeDateToCsv(headers, file) {
                value = item[header]
                //-- Check if timestamp, there is maybe a better way to do this
                if(typeof value === "number" && value > 1400000000000)
-                  value = moment(parseInt(value)).format('dddd D MMMM YYYY à kk:mm')
+                  value = moment(parseInt(value)).format('YYYY/MM/D-kk:mm')
 
             } else {
                value = ""

--- a/bin/dynamo-restore.js
+++ b/bin/dynamo-restore.js
@@ -20,9 +20,9 @@ var sleep = require('sleep');
 
 var argv = utils.config({
     demand: ['table'],
-    optional: ['rate', 'key', 'secret', 'region'],
+    optional: ['rate', 'key', 'secret', 'region', 'endpoint'],
     usage: 'Restores Dynamo DB table from JSON file\n' +
-           'Usage: dynamo-archive --table my-table [--rate 100] [--region us-east-1] [--key AK...AA] [--secret 7a...IG]'
+           'Usage: dynamo-restore --table my-table [--rate 100] [--region us-east-1] [--key AK...AA] [--secret 7a...IG] [--endpoint http://localhost:8000]'
 });
 
 var dynamo = utils.dynamo(argv);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,11 +28,11 @@ module.exports.dynamo = function(opts) {
             region: opts.region || process.env.AWS_DEFAULT_REGION || 'us-east-1'
         }
     );
-    var opts = {};
-    if (process.env.AWS_DYNAMODB_ENDPOINT){
-        opts.endpoint = new aws.Endpoint(process.env.AWS_DYNAMODB_ENDPOINT);
+    var params = {};
+    if (opts.endpoint || process.env.AWS_DYNAMODB_ENDPOINT){
+        params.endpoint = new aws.Endpoint(opts.endpoint || process.env.AWS_DYNAMODB_ENDPOINT);
     }
-    return new aws.DynamoDB(opts);
+    return new aws.DynamoDB(params);
 };
 
 // `opts` should be an object with keys: demand, optional, usage

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,39 @@ var aws = require('aws-sdk');
 
 module.exports = {};
 
+module.exports.csv =  function(array) {
+    var str = "";
+    for (var i = 0; i < array.length; i++) {
+        str += array[i].toString().replace(/\r?\n/g, "")
+        if (i != array.length - 1) str += ";"
+    };
+    return str;
+}
+
+module.exports.flatten = function(data) {
+    var result = {};
+    function recurse (cur, prop) {
+        if (Object(cur) !== cur) {
+            result[prop] = cur;
+        } else if (Array.isArray(cur)) {
+             for(var i=0, l=cur.length; i<l; i++)
+                 recurse(cur[i], prop + "[" + i + "]");
+            if (l == 0)
+                result[prop] = [];
+        } else {
+            var isEmpty = true;
+            for (var p in cur) {
+                isEmpty = false;
+                recurse(cur[p], prop ? prop+"."+p : p);
+            }
+            if (isEmpty && prop)
+                result[prop] = {};
+        }
+    }
+    recurse(data, "");
+    return result;
+}
+
 module.exports.dynamo = function(opts) {
     aws.config.update(
         {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "aws-sdk": "2.2.x",
     "minimist": "1.1.x",
     "sleep": "3.0.x",
-    "dotenv": "0.4.x"
+    "dotenv": "0.4.x",
+    "moment-timezone": "0.5.11",
+    "dynamodb-marshaler": "1.2.2"
   },
   "devDependencies": {
     "tape": "~2.13.2",
@@ -18,7 +20,8 @@
   },
   "bin": {
     "dynamo-archive": "bin/dynamo-archive.js",
-    "dynamo-restore": "bin/dynamo-restore.js"
+    "dynamo-restore": "bin/dynamo-restore.js",
+    "dynamo-export": "bin/dynamo-export.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added bin/dynamo-export.js, this will read the JSON files the dynamo-archive.js outputs and transforms it into a CSV file (much easier to work with)
Also, I added an option to specify the local dynamodb endpoint (instead of the process.env)
