### PR TITLE
Migrate restore script to promises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
-language: nodejs
+language: node_js
+
+cache:
+  directories:
+    - "node_modules"
+
 branches:
   only:
     - master
+
 install:
   - npm install
+
 script:
   - npm test
 
+node_js:
+  - "6"
+  - "7"

--- a/bin/dynamo-restore.js
+++ b/bin/dynamo-restore.js
@@ -20,9 +20,9 @@ var sleep = require('sleep');
 
 var argv = utils.config({
     demand: ['table'],
-    optional: ['rate', 'key', 'secret', 'region'],
+    optional: ['rate', 'key', 'secret', 'region', 'v'],
     usage: 'Restores Dynamo DB table from JSON file\n' +
-           'Usage: dynamo-archive --table my-table [--rate 100] [--region us-east-1] [--key AK...AA] [--secret 7a...IG]'
+           'Usage: dynamo-archive --table my-table [-v] [--rate 100] [--region us-east-1] [--key AK...AA] [--secret 7a...IG]'
 });
 
 delay = t => new Promise(resolve => { setTimeout(resolve, t) })
@@ -56,7 +56,7 @@ dynamo.describeTable({ TableName: argv.table }, (err, data) => {
                 }))
             }
         ).on('close', function() {
-            console.log(`Total promises: ${promises.length}`)
+            argv.v && console.log(`Total promises: ${promises.length}`)
 
             var batches = promises.reduce((set, promise) => {
                 var current = set.length - 1
@@ -71,13 +71,13 @@ dynamo.describeTable({ TableName: argv.table }, (err, data) => {
 
                     return delay(1000)
                         .then(() => Promise.all(batch.map(promise => promise())) )
-                        .then(() => { console.log(`Processed a batch with ${batch.length} items`) })
+                        .then(() => { argv.v && console.log(`Processed a batch with ${batch.length} items`) })
             })
 
-            console.log(`Processing ${promiseBatches.length} batches of promises, up to ${quota} promises each`)
+            argv.v && console.log(`Processing ${promiseBatches.length} batches of promises, up to ${quota} promises each`)
 
             Promise.series(promiseBatches, {}).then(() => {
-                console.log('All done, hooray!')
+                argv.v && console.log('All done, hooray!')
             }).catch(err => {
                 console.log(err)
             })

--- a/bin/dynamo-restore.js
+++ b/bin/dynamo-restore.js
@@ -25,43 +25,73 @@ var argv = utils.config({
            'Usage: dynamo-archive --table my-table [--rate 100] [--region us-east-1] [--key AK...AA] [--secret 7a...IG]'
 });
 
+delay = t => new Promise(resolve => { setTimeout(resolve, t) })
+
 var dynamo = utils.dynamo(argv);
-dynamo.describeTable(
-    {
-        TableName: argv.table
-    },
-    function (err, data) {
-        if (err != null) {
-            throw err;
-        }
-        if (data == null) {
-            throw 'Table ' + argv.table + ' not found in DynamoDB';
-        }
+
+dynamo.describeTable({ TableName: argv.table }, (err, data) => {
+        if (err != null) throw err
+        if (data == null) throw 'Table ' + argv.table + ' not found in DynamoDB'
+
         var quota = data.Table.ProvisionedThroughput.WriteCapacityUnits;
-        var start = Date.now();
-        var msecPerItem = Math.round(1000 / quota / ((argv.rate || 100) / 100));
-        var done = 0;
-        readline.createInterface(process.stdin, process.stdout).on(
+        var promises = []
+        var counter = 0
+
+        readline.createInterface({input: process.stdin, terminal: false, output: process.stdout}).on(
             'line',
-            function(line) {
-                dynamo.putItem(
-                    {
-                        TableName: argv.table,
-                        Item: JSON.parse(line)
-                    },
-                    function (err, data) {
-                        if (err) {
-                            console.log(err, err.stack);
-                            throw err;
+            line => {
+                promises.push(() => new Promise((resolve, reject) => {
+                    dynamo.putItem({
+                            TableName: argv.table,
+                            Item: JSON.parse(line)
+                        }, (err, data) => {
+                            if (err) {
+                                console.log(err, err.stack);
+                                return reject(err)
+                            }
+
+                            resolve()
                         }
-                    }
-                );
-                ++done;
-                var expected = start + msecPerItem * done;
-                if (expected > Date.now()) {
-                    sleep.usleep((expected - Date.now()) * 1000);
-                }
+                    );
+                }))
             }
-        );
+        ).on('close', function() {
+            console.log(`Total promises: ${promises.length}`)
+
+            var batches = promises.reduce((set, promise) => {
+                var current = set.length - 1
+                set[current].push(promise)
+                if (set[current].length == quota) set.push([])
+
+                return set
+            }, [[]])
+
+            var promiseBatches = batches.map(batch => () => {
+                    if (batch.length == 0) return Promise.resolve()
+
+                    return delay(1000)
+                        .then(() => Promise.all(batch.map(promise => promise())) )
+                        .then(() => { console.log(`Processed a batch with ${batch.length} items`) })
+            })
+
+            console.log(`Processing ${promiseBatches.length} batches of promises, up to ${quota} promises each`)
+
+            Promise.series(promiseBatches, {}).then(() => {
+                console.log('All done, hooray!')
+            }).catch(err => {
+                console.log(err)
+            })
+        });
     }
 );
+
+Promise.series = function(promises, initValue) {
+    return promises.reduce(function(chain, promise) {
+        if (typeof promise !== "function") {
+            return Promise.reject(
+                new Error("Error: Invalid promise item: " + promise)
+            )
+        }
+        return chain.then(promise)
+    }, Promise.resolve(initValue))
+}


### PR DESCRIPTION
Tested on a table with 100,000 entries
Migrated to promises and ES6 syntax because it's supported in Node
The new logic is like this:
Every line of the standard input creates one promise (an insert task), then these promises are grouped in batches depending on Writing Capacity. Eg. if there are 50 writing units, there will be 50 launched promises in parallel. Then, batches will run one after another in series that will allow to introduce delays.