### PR TITLE
Support on-demand read capacity

### DIFF
--- a/bin/dynamo-archive.js
+++ b/bin/dynamo-archive.js
@@ -68,10 +68,11 @@ dynamo.describeTable(
         if (data == null) {
             throw 'Table ' + argv.table + ' not found in DynamoDB';
         }
+        const rcu = data.Table.ProvisionedThroughput.ReadCapacityUnits;
         var params = {
             TableName: argv.table,
             ReturnConsumedCapacity: 'NONE',
-            Limit: data.Table.ProvisionedThroughput.ReadCapacityUnits
+            Limit: rcu > 0 ? rcu : 1000
         };
         if (argv.index) {
             params.IndexName = argv.index


### PR DESCRIPTION
When the table is set to use on-demand capacity `Table.ProvisionedThroughput.ReadCapacityUnits` returns 0 which is not valid when calculating `msecPerItem`. This PR sets the default to 1000 to avoid errors.